### PR TITLE
Set the initial bridge token cap for wNAM to be the same as the total supply

### DIFF
--- a/scripts/deploy.js
+++ b/scripts/deploy.js
@@ -148,7 +148,7 @@ async function main() {
     console.log(`Proxy address: ${proxy.address}`)
     console.log(`Governance address: ${governance.address}`)
     console.log(`Bridge address: ${bridge.address}`)
-    console.log(`Token address: ${wnamToken.address}`)
+    console.log(`wNAM token address: ${wnamToken.address}`)
     console.log("")
 
     await writeState(proxy.address, governance.address, bridge.address, wnamToken.address, hre.network.name, hre.network.config.chainId)
@@ -167,7 +167,7 @@ async function main() {
     console.log("Looking good!")
 }
 
-const writeState = async (proxyAddress, governanceAddress, bridgeAddress, tokenAddress, networkName, networkChainId) => {
+const writeState = async (proxyAddress, governanceAddress, bridgeAddress, wnamAddress, networkName, networkChainId) => {
     const filePath = `scripts/state-${networkName}-${networkChainId}.json`
     const stateExist = fs.existsSync(filePath)
 
@@ -175,7 +175,7 @@ const writeState = async (proxyAddress, governanceAddress, bridgeAddress, tokenA
         'proxy': proxyAddress,
         'governance': governanceAddress,
         'bridge': bridgeAddress,
-        'token': tokenAddress,
+        'wnam': wnamAddress,
         'network': {
             'name': networkName,
             'chainId': networkChainId


### PR DESCRIPTION
When running `deploy.js`, you don't need to specify the wNAM address when prompted for:

```
Whitelisted token address, comma separated:
```

but you do need to specify the wNAM bridge cap when prompted for:
```
Whitelisted token caps, comma separated:
```

This PR changes it so that wNAM doesn't need to be specified for either, and the wNAM total supply is always used as the initial bridge cap (this value should be updateable by validators anyway). Alternatively, we could explicitly prompt for the wNAM bridge cap, like how we explicitly prompt for the wNAM total supply? Or any other change that would make it so that the comma separated list for `Whitelisted token address` and `Whitelisted token caps` lines up 1:1.

Also renamed some relevant variables to include `wnam` in the name.