### PR TITLE
Fix token caps

### DIFF
--- a/contracts/interface/IBridge.sol
+++ b/contracts/interface/IBridge.sol
@@ -6,8 +6,6 @@ import "./ICommon.sol";
 interface IBridge is ICommon {
     event TransferToNamada(uint256 nonce, NamadaTransfer[] trasfers, bool[] validMap, uint256 confirmations);
 
-    event InvalidTransferToNamada(address from, string to, uint256 amount);
-
     event TransferToErc(uint256 indexed nonce, Erc20Transfer[] transfers, bool[] validMap, string relayerAddress);
 
     function authorize(


### PR DESCRIPTION
If the token caps were at 0, no transfers could be made to a whitelisted token. This PR also includes a commit that removes an unused event type.