### PR TITLE
Fix a typo in an event definition

### DIFF
--- a/contracts/contract/Bridge.sol
+++ b/contracts/contract/Bridge.sol
@@ -159,10 +159,10 @@ contract Bridge is IBridge, ReentrancyGuard {
         nextValidatorSetHash = _validatorSetHash;
     }
 
-    function updateTokenWhitelist(
-        address[] calldata _tokens,
-        uint256[] calldata _tokensCap
-    ) external onlyLatestGovernanceContract {
+    function updateTokenWhitelist(address[] calldata _tokens, uint256[] calldata _tokensCap)
+        external
+        onlyLatestGovernanceContract
+    {
         require(_tokens.length == _tokensCap.length, "Invalid inputs.");
         for (uint256 i = 0; i < _tokens.length; i++) {
             tokenWhiteList[_tokens[i]] = TokenCaps.Token(true, _tokensCap[i]);
@@ -251,10 +251,11 @@ contract Bridge is IBridge, ReentrancyGuard {
         return keccak256(abi.encode(version, "bridge", validators, powers, nonce));
     }
 
-    function _isEnoughVotingPower(
-        uint256[] memory _powers,
-        uint256 _thresholdVotingPower
-    ) internal pure returns (bool) {
+    function _isEnoughVotingPower(uint256[] memory _powers, uint256 _thresholdVotingPower)
+        internal
+        pure
+        returns (bool)
+    {
         uint256 powerAccumulator = 0;
 
         for (uint256 i = 0; i < _powers.length; i++) {
@@ -272,10 +273,11 @@ contract Bridge is IBridge, ReentrancyGuard {
             newValidatorSetArgs.validators.length == newValidatorSetArgs.powers.length;
     }
 
-    function _isValidSignatureSet(
-        ValidatorSetArgs calldata validatorSetArgs,
-        Signature[] calldata signature
-    ) internal pure returns (bool) {
+    function _isValidSignatureSet(ValidatorSetArgs calldata validatorSetArgs, Signature[] calldata signature)
+        internal
+        pure
+        returns (bool)
+    {
         return _isValidValidatorSetArg(validatorSetArgs) && validatorSetArgs.validators.length == signature.length;
     }
 

--- a/contracts/contract/Governance.sol
+++ b/contracts/contract/Governance.sol
@@ -199,10 +199,11 @@ contract Governance is IGovernance, ReentrancyGuard {
         return keccak256(abi.encode(version, "governance", validators, powers, nonce));
     }
 
-    function _isEnoughVotingPower(
-        uint256[] memory _powers,
-        uint256 _thresholdVotingPower
-    ) internal pure returns (bool) {
+    function _isEnoughVotingPower(uint256[] memory _powers, uint256 _thresholdVotingPower)
+        internal
+        pure
+        returns (bool)
+    {
         uint256 powerAccumulator = 0;
 
         for (uint256 i = 0; i < _powers.length; i++) {

--- a/contracts/contract/Vault.sol
+++ b/contracts/contract/Vault.sol
@@ -13,10 +13,11 @@ contract Vault is IVault {
         proxy = IProxy(_proxy);
     }
 
-    function batchTransferToErc20(
-        Erc20Transfer[] calldata _transfers,
-        bool[] calldata _validTransfers
-    ) external onlyLatestBridgeContract returns (bool[] memory) {
+    function batchTransferToErc20(Erc20Transfer[] calldata _transfers, bool[] calldata _validTransfers)
+        external
+        onlyLatestBridgeContract
+        returns (bool[] memory)
+    {
         bool[] memory transfersStatus = new bool[](_transfers.length);
 
         for (uint256 i = 0; i < _transfers.length; ++i) {

--- a/contracts/interface/IBridge.sol
+++ b/contracts/interface/IBridge.sol
@@ -4,7 +4,7 @@ pragma solidity ^0.8.19;
 import "./ICommon.sol";
 
 interface IBridge is ICommon {
-    event TransferToNamada(uint256 nonce, NamadaTransfer[] trasfers, bool[] validMap, uint256 confirmations);
+    event TransferToNamada(uint256 nonce, NamadaTransfer[] transfers, bool[] validMap, uint256 confirmations);
 
     event TransferToErc(uint256 indexed nonce, Erc20Transfer[] transfers, bool[] validMap, string relayerAddress);
 
@@ -14,7 +14,7 @@ interface IBridge is ICommon {
         bytes32 message
     ) external view returns (bool);
 
-    function transferToNamada(NamadaTransfer[] calldata trasfers, uint256 confirmations) external;
+    function transferToNamada(NamadaTransfer[] calldata transfers, uint256 confirmations) external;
 
     function transferToErc(RelayProof calldata relayProof) external;
 

--- a/contracts/interface/IVault.sol
+++ b/contracts/interface/IVault.sol
@@ -6,8 +6,7 @@ import "./ICommon.sol";
 interface IVault is ICommon {
     event InvalidTransfer(Erc20Transfer transfer);
 
-    function batchTransferToErc20(
-        Erc20Transfer[] calldata tranfers,
-        bool[] calldata validTransfers
-    ) external returns (bool[] memory);
+    function batchTransferToErc20(Erc20Transfer[] calldata tranfers, bool[] calldata validTransfers)
+        external
+        returns (bool[] memory);
 }


### PR DESCRIPTION
* Fix a typo in an event definition
* Run the linter, to apply the proposed fixes